### PR TITLE
Add unit tests for `ReminderProcessor` to validate reminder processing …

### DIFF
--- a/backend.Tests/Services/ReminderProcessorTests.cs
+++ b/backend.Tests/Services/ReminderProcessorTests.cs
@@ -1,0 +1,147 @@
+using backend.Data;
+using backend.Models;
+using backend.Services.Implementations;
+using backend.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace backend.Tests.Services;
+
+public class ReminderProcessorTests : IDisposable
+{
+    private readonly BulldogDbContext _context;
+    private readonly Mock<ILogger<ReminderProcessor>> _loggerMock;
+    private readonly Mock<INotificationService> _notificationServiceMock;
+
+    public ReminderProcessorTests()
+    {
+        var options = new DbContextOptionsBuilder<BulldogDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString()) // ensures clean DB per test
+            .Options;
+
+        _context = new BulldogDbContext(options);
+        _loggerMock = new Mock<ILogger<ReminderProcessor>>();
+    }
+
+    public void Dispose()
+    {
+        _context.Database.EnsureDeleted();
+        _context.Dispose();
+    }
+
+    [Fact]
+    public async Task ProcessDueRemindersAsync_UpdatesIsSent_ForDueReminders()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var reminder1 = new Reminder
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Message = "Test reminder 1",
+            ReminderTime = DateTime.UtcNow.AddMinutes(-1),
+            IsSent = false
+        };
+        var reminder2 = new Reminder
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Message = "Test reminder 2",
+            ReminderTime = DateTime.UtcNow.AddMinutes(10),
+            IsSent = false
+        };
+
+        _context.Reminders.AddRange(reminder1, reminder2);
+        await _context.SaveChangesAsync();
+
+        var notificationMock = new Mock<INotificationService>();
+        notificationMock
+            .Setup(x => x.SendReminderAsync(userId, It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+
+        var processor = new ReminderProcessor(_context, _loggerMock.Object, notificationMock.Object);
+
+        // Act
+        await processor.ProcessDueRemindersAsync();
+
+        // Assert
+        var updatedReminders = await _context.Reminders.ToListAsync();
+        Assert.True(updatedReminders.Single(r => r.Id == reminder1.Id).IsSent);
+        Assert.False(updatedReminders.Single(r => r.Id == reminder2.Id).IsSent);
+    }
+
+
+    [Fact]
+    public async Task ProcessDueRemindersAsync_SetsSentAtAndDoesNotIncrementSendAttempts_OnSuccess()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var userId = Guid.NewGuid();
+        var reminder = new Reminder
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Message = "Success test",
+            ReminderTime = now.AddMinutes(-1),
+            IsSent = false,
+            SendAttempts = 0
+        };
+
+        _context.Reminders.Add(reminder);
+        await _context.SaveChangesAsync();
+
+        var notificationMock = new Mock<INotificationService>();
+        notificationMock
+            .Setup(x => x.SendReminderAsync(userId, It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+
+        var processor = new ReminderProcessor(_context, _loggerMock.Object, notificationMock.Object);
+
+        // Act
+        await processor.ProcessDueRemindersAsync();
+
+        // Assert
+        var updated = await _context.Reminders.FindAsync(reminder.Id);
+        Assert.True(updated.IsSent);
+        Assert.NotNull(updated.SentAt);
+        Assert.Equal(0, updated.SendAttempts);
+    }
+
+    [Fact]
+    public async Task ProcessDueRemindersAsync_IncrementsSendAttempts_AndDoesNotSetSentAt_OnFailure()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var userId = Guid.NewGuid();
+        var reminder = new Reminder
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Message = "Failure test",
+            ReminderTime = now.AddMinutes(-1),
+            IsSent = false,
+            SendAttempts = 0
+        };
+
+        _context.Reminders.Add(reminder);
+        await _context.SaveChangesAsync();
+
+        var notificationMock = new Mock<INotificationService>();
+        notificationMock
+            .Setup(x => x.SendReminderAsync(userId, It.IsAny<string>(), It.IsAny<string>()))
+            .ThrowsAsync(new Exception("Mock failure"));
+
+        var processor = new ReminderProcessor(_context, _loggerMock.Object, notificationMock.Object);
+
+        // Act
+        await processor.ProcessDueRemindersAsync();
+
+        // Assert
+        var updated = await _context.Reminders.FindAsync(reminder.Id);
+        Assert.False(updated.IsSent);
+        Assert.Null(updated.SentAt);
+        Assert.Equal(1, updated.SendAttempts);
+    }
+
+}


### PR DESCRIPTION
…logic

- Implemented ReminderProcessorTests to cover scenarios for processing due reminders, including successful and failed attempts.
- Added tests to ensure reminders are updated correctly based on their status and that send attempts are tracked accurately.
- Utilized in-memory database for isolated testing of reminder processing functionality.