### PR TITLE
Add reminder functionality to ActionItem and Reminder models

### DIFF
--- a/backend/Dtos/ActionItems/ActionItemDto.cs
+++ b/backend/Dtos/ActionItems/ActionItemDto.cs
@@ -8,4 +8,7 @@ public class ActionItemDto
     public DateTime? DueAt { get; set; }
     public bool IsDateOnly { get; set; }
     public Guid SummaryId { get; set; }
+
+    public bool ShouldRemind { get; set; }
+    public int? ReminderMinutesBeforeDue { get; set; }
 }

--- a/backend/Dtos/ActionItems/CreateActionItemDto.cs
+++ b/backend/Dtos/ActionItems/CreateActionItemDto.cs
@@ -6,4 +6,7 @@ public class CreateActionItemDto
     public string Text { get; set; } = null!;
     public DateTime? DueAt { get; set; }
     public bool IsDateOnly { get; set; } = false;
+    public bool ShouldRemind { get; set; } = true;
+    public int? ReminderMinutesBeforeDue { get; set; }
+
 }

--- a/backend/Dtos/ActionItems/UpdateActionItemDto.cs
+++ b/backend/Dtos/ActionItems/UpdateActionItemDto.cs
@@ -6,4 +6,7 @@ public class UpdateActionItemDto
     public bool IsDone { get; set; }
     public DateTime? DueAt { get; set; }
     public bool IsDateOnly { get; set; } = false;
+
+    public bool ShouldRemind { get; set; } = true;
+    public int? ReminderMinutesBeforeDue { get; set; }
 }

--- a/backend/Mappers/ActionItemMapper.cs
+++ b/backend/Mappers/ActionItemMapper.cs
@@ -14,7 +14,9 @@ public static class ActionItemMapper
             IsDone = item.IsDone,
             DueAt = item.DueAt,
             IsDateOnly = item.IsDateOnly,
-            SummaryId = item.SummaryId
+            SummaryId = item.SummaryId,
+            ShouldRemind = item.ShouldRemind,
+            ReminderMinutesBeforeDue = item.ReminderMinutesBeforeDue
         };
     }
 

--- a/backend/Migrations/20250622224713_AddRemindInfoToActionItem.Designer.cs
+++ b/backend/Migrations/20250622224713_AddRemindInfoToActionItem.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using backend.Data;
@@ -11,9 +12,11 @@ using backend.Data;
 namespace backend.Migrations
 {
     [DbContext(typeof(BulldogDbContext))]
-    partial class BulldogDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250622224713_AddRemindInfoToActionItem")]
+    partial class AddRemindInfoToActionItem
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20250622224713_AddRemindInfoToActionItem.cs
+++ b/backend/Migrations/20250622224713_AddRemindInfoToActionItem.cs
@@ -1,0 +1,51 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRemindInfoToActionItem : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedAt",
+                table: "Reminders",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReminderMinutesBeforeDue",
+                table: "ActionItems",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ShouldRemind",
+                table: "ActionItems",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                table: "Reminders");
+
+            migrationBuilder.DropColumn(
+                name: "ReminderMinutesBeforeDue",
+                table: "ActionItems");
+
+            migrationBuilder.DropColumn(
+                name: "ShouldRemind",
+                table: "ActionItems");
+        }
+    }
+}

--- a/backend/Models/ActionItem.cs
+++ b/backend/Models/ActionItem.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace backend.Models
 {
     public class ActionItem
@@ -10,6 +8,9 @@ namespace backend.Models
         public bool IsDone { get; set; } = false;
         public DateTime? DueAt { get; set; }
         public bool IsDateOnly { get; set; } = false;
+
+        public bool ShouldRemind { get; set; } = true;
+        public int? ReminderMinutesBeforeDue { get; set; }
 
         public Summary? Summary { get; set; }
     }

--- a/backend/Models/Reminder.cs
+++ b/backend/Models/Reminder.cs
@@ -9,6 +9,7 @@ namespace backend.Models
 
         public string Message { get; set; } = string.Empty;
         public DateTime ReminderTime { get; set; }
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
         public bool IsSent { get; set; } = false;
         public DateTime? SentAt { get; set; }

--- a/backend/Services/Implementations/SesNotificationService.cs
+++ b/backend/Services/Implementations/SesNotificationService.cs
@@ -1,13 +1,12 @@
 using Amazon.SimpleEmail;
 using Amazon.SimpleEmail.Model;
 using backend.Data;
-using backend.Helpers;
 using backend.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
 namespace backend.Services.Implementations;
 
-public class SesNotificationService : INotificationService
+public partial class SesNotificationService : INotificationService
 {
     private readonly ILogger<SesNotificationService> _logger;
     private readonly IConfiguration _config;
@@ -57,7 +56,7 @@ public class SesNotificationService : INotificationService
 
     private async Task SendEmailAsync(string toEmail, string subject, string htmlBody)
     {
-        var fromEmail = _config["AmazonEmail:FromAddress"];
+        var fromEmail = _config["AWS:FromEmail"];
 
         var sendRequest = new SendEmailRequest
         {
@@ -69,7 +68,7 @@ public class SesNotificationService : INotificationService
                 Body = new Body
                 {
                     Html = new Content(htmlBody),
-                    Text = new Content(System.Text.RegularExpressions.Regex.Replace(htmlBody, "<.*?>", ""))
+                    Text = new Content(MyRegex().Replace(htmlBody, ""))
                 }
             }
         };
@@ -85,4 +84,7 @@ public class SesNotificationService : INotificationService
             .Select(u => u.Email)
             .FirstOrDefaultAsync();
     }
+
+    [System.Text.RegularExpressions.GeneratedRegex("<.*?>")]
+    private static partial System.Text.RegularExpressions.Regex MyRegex();
 }


### PR DESCRIPTION
- Introduced ShouldRemind and ReminderMinutesBeforeDue properties in ActionItemDto, CreateActionItemDto, and UpdateActionItemDto to manage reminder settings.
- Updated ActionItem model to include new properties for reminders.
- Enhanced ActionItemMapper to map reminder properties.
- Created migration to add ShouldRemind and ReminderMinutesBeforeDue columns to ActionItems table.
- Implemented logic in ActionItemService to generate and manage reminders based on user settings.
- Updated SummaryService to create reminders for action items during summary creation.