### PR TITLE
Remove CreatedAtLocal property from User model and related database c…

### DIFF
--- a/backend/Data/BulldogDbContext.cs
+++ b/backend/Data/BulldogDbContext.cs
@@ -22,10 +22,6 @@ namespace backend.Data
             base.OnModelCreating(modelBuilder);
 
             // Configure CreatedAtLocal fields to use timestamp without time zone
-            modelBuilder.Entity<User>()
-                .Property(u => u.CreatedAtLocal)
-                .HasColumnType("timestamp without time zone");
-
             modelBuilder.Entity<Summary>()
                 .Property(s => s.CreatedAtLocal)
                 .HasColumnType("timestamp without time zone");

--- a/backend/Data/DbSeeder.cs
+++ b/backend/Data/DbSeeder.cs
@@ -14,8 +14,7 @@ public static class DbSeeder
             Id = Guid.NewGuid(),
             Email = "testuser@example.com",
             DisplayName = "Test User",
-            CreatedAtUtc = DateTime.UtcNow,
-            CreatedAtLocal = DateTime.UtcNow // Test data uses UTC
+            CreatedAtUtc = DateTime.UtcNow
         };
 
         // Create summaries for the user

--- a/backend/Migrations/20250625040025_RemoveCreatedAtLocalFromUser.Designer.cs
+++ b/backend/Migrations/20250625040025_RemoveCreatedAtLocalFromUser.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using backend.Data;
@@ -11,9 +12,11 @@ using backend.Data;
 namespace backend.Migrations
 {
     [DbContext(typeof(BulldogDbContext))]
-    partial class BulldogDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250625040025_RemoveCreatedAtLocalFromUser")]
+    partial class RemoveCreatedAtLocalFromUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20250625040025_RemoveCreatedAtLocalFromUser.cs
+++ b/backend/Migrations/20250625040025_RemoveCreatedAtLocalFromUser.cs
@@ -1,0 +1,30 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveCreatedAtLocalFromUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedAtLocal",
+                table: "Users");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedAtLocal",
+                table: "Users",
+                type: "timestamp without time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+    }
+}

--- a/backend/Models/User.cs
+++ b/backend/Models/User.cs
@@ -9,7 +9,6 @@ namespace backend.Models
         public string DisplayName { get; set; } = string.Empty;
         public string PasswordHash { get; set; } = string.Empty;
         public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
-        public DateTime CreatedAtLocal { get; set; }
 
         //Email verification
         public bool EmailVerified { get; set; } = false;

--- a/backend/Services/Implementations/UserService.cs
+++ b/backend/Services/Implementations/UserService.cs
@@ -73,8 +73,7 @@ namespace backend.Services.Implementations
                 PasswordHash = hashedPassword,
                 PhoneNumber = dto.PhoneNumber,
                 TwoFactorEnabled = dto.EnableTwoFactor,
-                CreatedAtUtc = utcNow,
-                CreatedAtLocal = utcNow // Will be updated when user sets timezone
+                CreatedAtUtc = utcNow
             };
 
             _context.Users.Add(user);
@@ -105,8 +104,7 @@ namespace backend.Services.Implementations
                 PasswordHash = hashedPassword,
                 PhoneNumber = dto.PhoneNumber,
                 TwoFactorEnabled = dto.EnableTwoFactor,
-                CreatedAtUtc = utcNow,
-                CreatedAtLocal = utcNow // Will be updated when user sets timezone
+                CreatedAtUtc = utcNow
             };
 
             _context.Users.Add(user);


### PR DESCRIPTION
…onfigurations. Update DbSeeder and UserService to eliminate usage of CreatedAtLocal. This fixed bug where local time was being set as infinity on User Creation, because local time could not be calculated yet.