### PR TITLE
Refactor Reminder models and DTOs to enforce required ActionItemId an…

### DIFF
--- a/backend/Data/BulldogDbContext.cs
+++ b/backend/Data/BulldogDbContext.cs
@@ -67,7 +67,7 @@ namespace backend.Data
                     entity.HasOne(r => r.ActionItem)
                           .WithMany()
                           .HasForeignKey(r => r.ActionItemId)
-                          .OnDelete(DeleteBehavior.SetNull);
+                          .OnDelete(DeleteBehavior.Cascade); // Delete reminders if action item is deleted
 
                     // Properties
                     entity.Property(r => r.Message)

--- a/backend/Dtos/Reminders/CreateReminderDto.cs
+++ b/backend/Dtos/Reminders/CreateReminderDto.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace backend.Dtos.Reminders
 {
     public class CreateReminderDto
@@ -8,6 +6,6 @@ namespace backend.Dtos.Reminders
 
         public DateTime ReminderTime { get; set; }
 
-        public Guid? ActionItemId { get; set; } // Optional association
+        public Guid ActionItemId { get; set; }
     }
 }

--- a/backend/Dtos/Reminders/UpdateReminderDto.cs
+++ b/backend/Dtos/Reminders/UpdateReminderDto.cs
@@ -8,6 +8,6 @@ namespace backend.Dtos.Reminders
 
         public DateTime ReminderTime { get; set; }
 
-        public Guid? ActionItemId { get; set; } // Optional to change or unset
+        public Guid ActionItemId { get; set; }
     }
 }

--- a/backend/Migrations/20250701033156_MakeRemindersRequireActionItem.Designer.cs
+++ b/backend/Migrations/20250701033156_MakeRemindersRequireActionItem.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using backend.Data;
@@ -11,9 +12,11 @@ using backend.Data;
 namespace backend.Migrations
 {
     [DbContext(typeof(BulldogDbContext))]
-    partial class BulldogDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250701033156_MakeRemindersRequireActionItem")]
+    partial class MakeRemindersRequireActionItem
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -271,7 +274,7 @@ namespace backend.Migrations
                     b.HasOne("backend.Models.ActionItem", "ActionItem")
                         .WithMany()
                         .HasForeignKey("ActionItemId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.SetNull)
                         .IsRequired();
 
                     b.HasOne("backend.Models.User", "User")

--- a/backend/Migrations/20250701033156_MakeRemindersRequireActionItem.cs
+++ b/backend/Migrations/20250701033156_MakeRemindersRequireActionItem.cs
@@ -1,0 +1,37 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeRemindersRequireActionItem : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ActionItemId",
+                table: "Reminders",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ActionItemId",
+                table: "Reminders",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+        }
+    }
+}

--- a/backend/Migrations/20250701034434_ImplementCascadeDeleteOnReminders.Designer.cs
+++ b/backend/Migrations/20250701034434_ImplementCascadeDeleteOnReminders.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using backend.Data;
@@ -11,9 +12,11 @@ using backend.Data;
 namespace backend.Migrations
 {
     [DbContext(typeof(BulldogDbContext))]
-    partial class BulldogDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250701034434_ImplementCascadeDeleteOnReminders")]
+    partial class ImplementCascadeDeleteOnReminders
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20250701034434_ImplementCascadeDeleteOnReminders.cs
+++ b/backend/Migrations/20250701034434_ImplementCascadeDeleteOnReminders.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class ImplementCascadeDeleteOnReminders : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Reminders_ActionItems_ActionItemId",
+                table: "Reminders");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Reminders_ActionItems_ActionItemId",
+                table: "Reminders",
+                column: "ActionItemId",
+                principalTable: "ActionItems",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Reminders_ActionItems_ActionItemId",
+                table: "Reminders");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Reminders_ActionItems_ActionItemId",
+                table: "Reminders",
+                column: "ActionItemId",
+                principalTable: "ActionItems",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+    }
+}

--- a/backend/Models/Reminder.cs
+++ b/backend/Models/Reminder.cs
@@ -3,7 +3,6 @@ namespace backend.Models
     public class Reminder
     {
         public Guid Id { get; set; }
-
         public Guid UserId { get; set; }
         public User User { get; set; } = null!;
 
@@ -17,8 +16,7 @@ namespace backend.Models
         public int SendAttempts { get; set; } = 0;
         public int MaxSendAttempts { get; set; } = 3;
 
-
-        public Guid? ActionItemId { get; set; }
-        public ActionItem? ActionItem { get; set; }
+        public Guid ActionItemId { get; set; }
+        public ActionItem ActionItem { get; set; } = null!;
     }
 }

--- a/backend/Validators/Reminders/CreateReminderDtoValidator.cs
+++ b/backend/Validators/Reminders/CreateReminderDtoValidator.cs
@@ -16,7 +16,6 @@ public class CreateReminderDtoValidator : AbstractValidator<CreateReminderDto>
             .WithMessage("Reminder time must be at least 1 second in the future.");
 
         RuleFor(x => x.ActionItemId)
-            .Must(id => id == null || id != Guid.Empty)
-            .WithMessage("Invalid ActionItem ID.");
+            .NotEmpty().WithMessage("ActionItem ID is required.");
     }
 }

--- a/backend/Validators/Reminders/UpdateReminderDtoValidator.cs
+++ b/backend/Validators/Reminders/UpdateReminderDtoValidator.cs
@@ -14,5 +14,8 @@ public class UpdateReminderDtoValidator : AbstractValidator<UpdateReminderDto>
         RuleFor(x => x.ReminderTime)
             .Must((dto, reminderTime) => reminderTime > DateTime.UtcNow.AddSeconds(-10))
             .WithMessage("Reminder time must be at least 1 second in the future.");
+
+        RuleFor(x => x.ActionItemId)
+            .NotEmpty().WithMessage("ActionItem ID is required.");
     }
 }


### PR DESCRIPTION
…d update deletion behavior.

- Changed ActionItemId from nullable to required in CreateReminderDto, UpdateReminderDto, and Reminder model.
- Updated deletion behavior in BulldogDbContext to cascade delete reminders when the associated action item is deleted.
- Adjusted validation rules in CreateReminderDtoValidator and UpdateReminderDtoValidator to require ActionItemId.